### PR TITLE
Add motion-driven webcam particle visualizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,12 @@
 <body>
   <main>
     <h1>Motion Particle Camera</h1>
-    <p class="notice">Grant camera access to generate particles wherever motion is detected.</p>
+    <p class="notice">Click start and allow camera access to generate particles wherever motion is detected.</p>
     <div class="canvas-container">
       <video id="video" autoplay playsinline muted></video>
       <canvas id="particleCanvas"></canvas>
     </div>
+    <button id="startButton" type="button" class="start-button">Start camera</button>
     <p class="hint">Move in front of the camera to see particle trails. Use brighter lighting for better results.</p>
   </main>
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Motion Particle Camera</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <h1>Motion Particle Camera</h1>
+    <p class="notice">Grant camera access to generate particles wherever motion is detected.</p>
+    <div class="canvas-container">
+      <video id="video" autoplay playsinline muted></video>
+      <canvas id="particleCanvas"></canvas>
+    </div>
+    <p class="hint">Move in front of the camera to see particle trails. Use brighter lighting for better results.</p>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,170 @@
+const video = document.getElementById("video");
+const particleCanvas = document.getElementById("particleCanvas");
+const particleCtx = particleCanvas.getContext("2d");
+const motionCanvas = document.createElement("canvas");
+const motionCtx = motionCanvas.getContext("2d");
+
+const particles = [];
+const MAX_PARTICLES = 600;
+const MOTION_SAMPLE_STEP = 4; // pixels between samples
+const MOTION_THRESHOLD = 40; // sensitivity for motion detection
+
+let previousFrame = null;
+let animationFrameId = null;
+
+async function setupCamera() {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    displayError(
+      "Webcam access is not supported in this browser. Please try a modern browser such as Chrome or Firefox."
+    );
+    return;
+  }
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode: "user" },
+      audio: false,
+    });
+    video.srcObject = stream;
+    await video.play();
+    handleResize();
+    startLoop();
+  } catch (error) {
+    console.error("Unable to access camera", error);
+    displayError(
+      "Camera access was blocked. Please allow webcam permissions and reload the page."
+    );
+  }
+}
+
+function displayError(message) {
+  const notice = document.querySelector(".notice");
+  if (notice) {
+    notice.textContent = message;
+    notice.classList.add("error");
+  }
+}
+
+function handleResize() {
+  const width = video.videoWidth || video.clientWidth;
+  const height = video.videoHeight || video.clientHeight;
+  if (!width || !height) {
+    return;
+  }
+
+  particleCanvas.width = width;
+  particleCanvas.height = height;
+  motionCanvas.width = width;
+  motionCanvas.height = height;
+}
+
+function startLoop() {
+  if (animationFrameId) {
+    cancelAnimationFrame(animationFrameId);
+  }
+
+  const render = () => {
+    if (video.readyState >= 2) {
+      detectMotion();
+      updateParticles();
+      drawParticles();
+    }
+    animationFrameId = requestAnimationFrame(render);
+  };
+
+  render();
+}
+
+function detectMotion() {
+  const { width, height } = motionCanvas;
+  motionCtx.drawImage(video, 0, 0, width, height);
+  const currentFrame = motionCtx.getImageData(0, 0, width, height);
+
+  if (previousFrame) {
+    const { data } = currentFrame;
+    const prevData = previousFrame.data;
+    const motionSpots = [];
+
+    for (let y = 0; y < height; y += MOTION_SAMPLE_STEP) {
+      for (let x = 0; x < width; x += MOTION_SAMPLE_STEP) {
+        const index = (y * width + x) * 4;
+        const diff =
+          Math.abs(data[index] - prevData[index]) +
+          Math.abs(data[index + 1] - prevData[index + 1]) +
+          Math.abs(data[index + 2] - prevData[index + 2]);
+
+        if (diff > MOTION_THRESHOLD * 3) {
+          motionSpots.push({ x, y, diff });
+        }
+      }
+    }
+
+    spawnParticles(motionSpots);
+  }
+
+  previousFrame = currentFrame;
+}
+
+function spawnParticles(motionSpots) {
+  const strengthScale = Math.min(1, motionSpots.length / 200);
+
+  motionSpots.forEach(({ x, y, diff }) => {
+    const normalizedStrength = Math.min(1, diff / (255 * 3));
+    const count = 1 + Math.floor(normalizedStrength * 3 * (1 + strengthScale));
+
+    for (let i = 0; i < count; i++) {
+      if (particles.length >= MAX_PARTICLES) {
+        particles.shift();
+      }
+
+      const angle = Math.random() * Math.PI * 2;
+      const speed = Math.random() * 2 + normalizedStrength * 2;
+
+      particles.push({
+        x: x + (Math.random() - 0.5) * MOTION_SAMPLE_STEP,
+        y: y + (Math.random() - 0.5) * MOTION_SAMPLE_STEP,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - 0.5,
+        life: 1,
+        decay: 0.01 + Math.random() * 0.02,
+        hue: (200 + normalizedStrength * 100 + Math.random() * 40) % 360,
+      });
+    }
+  });
+}
+
+function updateParticles() {
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.x += p.vx;
+    p.y += p.vy;
+    p.vy += 0.03; // gravity-like effect
+    p.life -= p.decay;
+
+    if (p.life <= 0) {
+      particles.splice(i, 1);
+    }
+  }
+}
+
+function drawParticles() {
+  particleCtx.clearRect(0, 0, particleCanvas.width, particleCanvas.height);
+  particleCtx.globalCompositeOperation = "lighter";
+
+  particles.forEach((p) => {
+    const alpha = Math.max(0, p.life);
+    const radius = 2 + (1 - alpha) * 3;
+
+    particleCtx.beginPath();
+    particleCtx.fillStyle = `hsla(${p.hue}, 90%, 60%, ${alpha})`;
+    particleCtx.arc(p.x, p.y, radius, 0, Math.PI * 2);
+    particleCtx.fill();
+  });
+
+  particleCtx.globalCompositeOperation = "source-over";
+}
+
+window.addEventListener("resize", handleResize);
+video.addEventListener("loadedmetadata", handleResize);
+
+setupCamera();

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@ const particleCanvas = document.getElementById("particleCanvas");
 const particleCtx = particleCanvas.getContext("2d");
 const motionCanvas = document.createElement("canvas");
 const motionCtx = motionCanvas.getContext("2d");
+const startButton = document.getElementById("startButton");
+const notice = document.querySelector(".notice");
 
 const particles = [];
 const MAX_PARTICLES = 600;
@@ -11,38 +13,71 @@ const MOTION_THRESHOLD = 40; // sensitivity for motion detection
 
 let previousFrame = null;
 let animationFrameId = null;
+let activeStream = null;
+let hasLoopStarted = false;
 
 async function setupCamera() {
+  if (!startButton) {
+    return;
+  }
+
+  if (activeStream) {
+    return;
+  }
+
   if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-    displayError(
-      "Webcam access is not supported in this browser. Please try a modern browser such as Chrome or Firefox."
+    setNotice(
+      "Webcam access is not supported in this browser. Please try a modern browser such as Chrome or Firefox.",
+      true
     );
+    startButton.disabled = true;
     return;
   }
 
   try {
-    const stream = await navigator.mediaDevices.getUserMedia({
+    startButton.disabled = true;
+    startButton.textContent = "Requesting access...";
+    setNotice("Please allow camera access in the browser prompt to start the effect.");
+
+    activeStream = await navigator.mediaDevices.getUserMedia({
       video: { facingMode: "user" },
       audio: false,
     });
-    video.srcObject = stream;
+
+    video.srcObject = activeStream;
     await video.play();
     handleResize();
-    startLoop();
+    if (!hasLoopStarted) {
+      startLoop();
+      hasLoopStarted = true;
+    }
+    startButton.textContent = "Camera running";
+    setTimeout(() => {
+      startButton.style.display = "none";
+    }, 800);
+    setNotice("Move in front of the camera to paint with particles.");
   } catch (error) {
     console.error("Unable to access camera", error);
-    displayError(
-      "Camera access was blocked. Please allow webcam permissions and reload the page."
+    if (activeStream) {
+      activeStream.getTracks().forEach((track) => track.stop());
+      activeStream = null;
+    }
+    setNotice(
+      "Camera access was blocked. Please allow webcam permissions and try again.",
+      true
     );
+    startButton.disabled = false;
+    startButton.textContent = "Try again";
   }
 }
 
-function displayError(message) {
-  const notice = document.querySelector(".notice");
-  if (notice) {
-    notice.textContent = message;
-    notice.classList.add("error");
+function setNotice(message, isError = false) {
+  if (!notice) {
+    return;
   }
+
+  notice.textContent = message;
+  notice.classList.toggle("error", Boolean(isError));
 }
 
 function handleResize() {
@@ -167,4 +202,14 @@ function drawParticles() {
 window.addEventListener("resize", handleResize);
 video.addEventListener("loadedmetadata", handleResize);
 
-setupCamera();
+if (startButton) {
+  startButton.addEventListener("click", () => {
+    setupCamera();
+  });
+}
+
+window.addEventListener("beforeunload", () => {
+  if (activeStream) {
+    activeStream.getTracks().forEach((track) => track.stop());
+  }
+});

--- a/style.css
+++ b/style.css
@@ -66,6 +66,37 @@ video,
   pointer-events: none;
 }
 
+.start-button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.8rem 2.4rem;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #0f172a;
+  background: linear-gradient(135deg, #38bdf8, #a855f7);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  box-shadow: 0 15px 30px rgba(56, 189, 248, 0.35);
+}
+
+.start-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 38px rgba(168, 85, 247, 0.45);
+}
+
+.start-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+}
+
+.start-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
 @media (max-width: 600px) {
   body {
     padding: 1.5rem 1rem 2.5rem;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,77 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem 3rem;
+  box-sizing: border-box;
+}
+
+main {
+  width: min(900px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  text-align: center;
+}
+
+h1 {
+  margin: 0.25rem 0;
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.notice,
+.hint {
+  max-width: 640px;
+  line-height: 1.5;
+  margin: 0;
+  opacity: 0.8;
+}
+
+.notice.error {
+  color: #fca5a5;
+  opacity: 1;
+}
+
+.canvas-container {
+  position: relative;
+  width: min(90vw, 800px);
+  aspect-ratio: 4 / 3;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.6);
+}
+
+video,
+#particleCanvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+#particleCanvas {
+  pointer-events: none;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .canvas-container {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page interface that requests webcam access and displays the live feed
- render particle animations driven by motion detection between video frames
- style the experience with responsive layout and clear error messaging

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4076c7224832a900077ad53c5d253