### PR TITLE
Simplify storyboard frontend with client-side mock data

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,12 +11,10 @@
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.1.1",
         "@tanstack/react-query": "^5.28.4",
-        "axios": "^1.6.8",
         "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.2",
-        "uuid": "^9.0.1",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -1726,12 +1724,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1784,17 +1776,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1908,6 +1889,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2064,18 +2046,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2251,15 +2221,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2291,6 +2252,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2395,6 +2357,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2404,6 +2367,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2441,6 +2405,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2453,6 +2418,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2893,26 +2859,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2944,22 +2890,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3002,6 +2932,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3062,6 +2993,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3086,6 +3018,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3185,6 +3118,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3256,6 +3190,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3268,6 +3203,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3283,6 +3219,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4020,6 +3957,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4047,27 +3985,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4697,12 +4614,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5863,19 +5774,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vite": {
       "version": "5.4.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,12 +12,10 @@
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.1.1",
     "@tanstack/react-query": "^5.28.4",
-    "axios": "^1.6.8",
     "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.2",
-    "uuid": "^9.0.1",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/frontend/src/hooks/useFrameMutations.ts
+++ b/frontend/src/hooks/useFrameMutations.ts
@@ -1,28 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
-import { v4 as uuid } from 'uuid';
 
-import { Frame } from '../state/types';
+import { createFrame as createFrameEntry } from '../state/mockService';
 
 const useFrameMutations = (projectId: string) => {
   const client = useQueryClient();
 
   const createFrame = useMutation({
-    mutationFn: async () => {
-      const frame: Frame = {
-        id: uuid(),
-        project_id: projectId,
-        frame_number: Date.now(),
-        prompt: 'Describe the action in the scene.',
-        sketch: {},
-        metadata: {},
-        selected_characters: [],
-        selected_locations: [],
-        selected_props: [],
-      };
-      const response = await axios.post(`/api/projects/${projectId}/frames`, frame);
-      return response.data as Frame;
-    },
+    mutationFn: () => createFrameEntry(projectId),
     onSuccess: () => {
       client.invalidateQueries({ queryKey: ['project', projectId] });
     },

--- a/frontend/src/hooks/useGenerationMutations.ts
+++ b/frontend/src/hooks/useGenerationMutations.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
 
+import { confirmGeneration, generateForFrame } from '../state/mockService';
 import { GenerationSettingsInput } from '../state/types';
 
 const useGenerationMutations = (frameId?: string, projectId?: string) => {
@@ -17,16 +17,10 @@ const useGenerationMutations = (frameId?: string, projectId?: string) => {
 
   const generate = useMutation({
     mutationFn: async (settings: GenerationSettingsInput) => {
-      if (!frameId) return [];
-      const payload = {
-        mode: settings.mode,
-        iterations: settings.iterations ?? (settings.mode === 'turbo' ? 4 : 2),
-        style_strength: 75,
-        prompt_weight: 80,
-        aspect_ratio: '16:9',
-      };
-      const response = await axios.post(`/api/frames/${frameId}/generate`, payload);
-      return response.data;
+      if (!frameId) {
+        throw new Error('Frame not selected');
+      }
+      return generateForFrame(frameId, settings);
     },
     onSuccess: () => {
       invalidateRelatedQueries();
@@ -34,10 +28,7 @@ const useGenerationMutations = (frameId?: string, projectId?: string) => {
   });
 
   const confirm = useMutation({
-    mutationFn: async (generationId: string) => {
-      const response = await axios.post(`/api/generations/${generationId}/confirm`);
-      return response.data;
-    },
+    mutationFn: (generationId: string) => confirmGeneration(generationId),
     onSuccess: () => {
       invalidateRelatedQueries();
     },

--- a/frontend/src/hooks/useGenerations.ts
+++ b/frontend/src/hooks/useGenerations.ts
@@ -1,17 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 
-import { Generation } from '../state/types';
-
-const fetchGenerations = async (frameId: string): Promise<Generation[]> => {
-  const response = await axios.get<Generation[]>(`/api/frames/${frameId}/generations`);
-  return response.data;
-};
+import { listGenerations } from '../state/mockService';
 
 const useGenerations = (frameId: string | null) => {
   return useQuery({
     queryKey: ['generations', frameId],
-    queryFn: () => fetchGenerations(frameId ?? ''),
+    queryFn: () => listGenerations(frameId ?? ''),
     enabled: Boolean(frameId),
     initialData: [],
   });

--- a/frontend/src/hooks/useProjectDetail.ts
+++ b/frontend/src/hooks/useProjectDetail.ts
@@ -1,17 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 
-import { ProjectDetail } from '../state/types';
-
-const fetchProject = async (projectId: string): Promise<ProjectDetail> => {
-  const response = await axios.get<ProjectDetail>(`/api/projects/${projectId}`);
-  return response.data;
-};
+import { getProjectDetail } from '../state/mockService';
 
 const useProjectDetail = (projectId: string) => {
   return useQuery({
     queryKey: ['project', projectId],
-    queryFn: () => fetchProject(projectId),
+    queryFn: () => getProjectDetail(projectId),
     enabled: Boolean(projectId),
   });
 };

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,23 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 
-export interface ProjectSummary {
-  id: string;
-  name: string;
-  description?: string;
-  frames?: string[];
-  updated_at: string;
-}
-
-const fetchProjects = async (): Promise<ProjectSummary[]> => {
-  const response = await axios.get<ProjectSummary[]>('/api/projects');
-  return response.data;
-};
+import { listProjectSummaries } from '../state/mockService';
+import { ProjectSummary } from '../state/types';
 
 const useProjects = () => {
   return useQuery({
     queryKey: ['projects'],
-    queryFn: fetchProjects,
+    queryFn: listProjectSummaries,
     initialData: [],
   });
 };

--- a/frontend/src/hooks/useSketchUpload.ts
+++ b/frontend/src/hooks/useSketchUpload.ts
@@ -1,19 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
 
-import { Frame } from '../state/types';
-
+import { uploadSketch } from '../state/mockService';
 
 const useSketchUpload = (projectId: string, frameId: string) => {
   const client = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async (file: File) => {
-      const formData = new FormData();
-      formData.append('file', file);
-      const response = await axios.post<Frame>(`/api/frames/${frameId}/sketch`, formData);
-      return response.data;
-    },
+    mutationFn: (file: File) => uploadSketch(projectId, frameId, file),
     onSuccess: () => {
       client.invalidateQueries({ queryKey: ['project', projectId] });
     },

--- a/frontend/src/hooks/useVideoProviders.ts
+++ b/frontend/src/hooks/useVideoProviders.ts
@@ -1,17 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 
-import { VideoProvider } from '../state/types';
-
-const fetchVideoProviders = async (): Promise<VideoProvider[]> => {
-  const response = await axios.get<VideoProvider[]>('/api/ai/video/providers');
-  return response.data;
-};
+import { listVideoProviders } from '../state/mockService';
 
 const useVideoProviders = () => {
   return useQuery({
     queryKey: ['video-providers'],
-    queryFn: fetchVideoProviders,
+    queryFn: listVideoProviders,
     initialData: [],
   });
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,9 +4,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import App from './App';
+import { ensureMockData } from './state/mockService';
 import './styles.css';
 
 const client = new QueryClient();
+
+ensureMockData();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/frontend/src/state/mockService.ts
+++ b/frontend/src/state/mockService.ts
@@ -1,0 +1,522 @@
+import { ProjectDetail, ProjectSummary, Frame, Generation, GenerationSettingsInput, VideoProvider } from './types';
+
+interface MockDatabase {
+  projects: ProjectDetail[];
+  generations: Record<string, Generation[]>;
+  videoProviders: VideoProvider[];
+}
+
+const STORAGE_KEY = 'storyboard-ai-mock-db';
+
+const deepClone = <T>(value: T): T => {
+  if (typeof globalThis !== 'undefined' && 'structuredClone' in globalThis) {
+    return (globalThis as typeof globalThis & { structuredClone: <U>(input: U) => U }).structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+const iso = (value: string) => new Date(value).toISOString();
+
+const defaultDatabase: MockDatabase = {
+  projects: [
+    {
+      id: 'demo-reel',
+      name: 'Skyward Launch Storyboard',
+      description: 'High-energy visual development boards for a sci-fi product reveal trailer.',
+      default_prompts: {
+        black_and_white: {
+          base: 'Cinematic storyboard sketch, graphite pencil on textured paper, dramatic lighting, expressive linework, dynamic perspective, production-ready keyframe, moody shadows, film noir sensibility.',
+          user_customization: 'Focus on gesture clarity and leading lines that guide the viewer through the action beat.',
+        },
+        color: {
+          base: 'Stylized cinematic concept art, volumetric lighting, vibrant color script, atmospheric depth, high-end animation still, painterly textures, story-driven composition.',
+          user_customization: 'Emphasize neon accents and warm rim light to accent hero moments.',
+        },
+      },
+      frames: [
+        {
+          id: 'frame-1',
+          project_id: 'demo-reel',
+          frame_number: 1,
+          prompt:
+            'The hero surveys the city from a rain-slick rooftop as neon billboards pulse in the distance, cloak whipping in the wind.',
+          sketch: {
+            image_url: 'https://placehold.co/640x360/020617/38bdf8?text=Sketch+1',
+            file_name: 'frame-1-sketch.png',
+            uploaded_at: iso('2024-02-05T09:00:00Z'),
+          },
+          metadata: {
+            scene: 'Opening Vista',
+            notes: 'Maintain wide lens energy with slow push-in.',
+          },
+          selected_characters: ['character-nova'],
+          selected_locations: ['location-rooftop'],
+          selected_props: ['prop-hoverboard'],
+          confirmed_image_url: 'https://placehold.co/640x360/0ea5e9/020617?text=Confirmed+Color',
+          confirmed_type: 'color',
+          confirmed_generation_id: 'gen-color-1',
+        },
+        {
+          id: 'frame-2',
+          project_id: 'demo-reel',
+          frame_number: 2,
+          prompt: 'Close-up on the hero activating a holographic wrist console while rain beads catch the blue light.',
+          sketch: {
+            image_url: 'https://placehold.co/640x360/020617/7dd3fc?text=Sketch+2',
+            file_name: 'frame-2-sketch.png',
+            uploaded_at: iso('2024-02-06T15:30:00Z'),
+          },
+          metadata: {
+            scene: 'Mission Briefing',
+            notes: 'Highlight hologram glow and reflective rain details.',
+          },
+          selected_characters: ['character-nova'],
+          selected_locations: ['location-command'],
+          selected_props: ['prop-console'],
+          confirmed_image_url: 'https://placehold.co/640x360/1e293b/d1d5db?text=Confirmed+B%26W',
+          confirmed_type: 'blackAndWhite',
+          confirmed_generation_id: 'gen-bw-2',
+        },
+        {
+          id: 'frame-3',
+          project_id: 'demo-reel',
+          frame_number: 3,
+          prompt: 'Dynamic chase through aerial traffic as the hero dives between hovering cargo skiffs.',
+          sketch: {
+            image_url: 'https://placehold.co/640x360/020617/64748b?text=Sketch+3',
+            file_name: 'frame-3-sketch.png',
+            uploaded_at: iso('2024-02-08T11:10:00Z'),
+          },
+          metadata: {
+            scene: 'Skyway Pursuit',
+            notes: 'Use dutch angle and motion blur streaks.',
+          },
+          selected_characters: ['character-nova', 'character-drone'],
+          selected_locations: ['location-skyway'],
+          selected_props: ['prop-hoverboard'],
+          confirmed_image_url: null,
+          confirmed_type: null,
+          confirmed_generation_id: null,
+        },
+      ],
+      characters: [
+        {
+          id: 'character-nova',
+          project_id: 'demo-reel',
+          name: 'Nova Reyes',
+          description: 'Agile pilot leading the launch mission; expressive eyes and confident posture.',
+          consistency_prompt: 'Keep Nova in a tactical flight suit with teal accents and short windswept hair.',
+          reference_images: ['https://placehold.co/120x160/0f172a/38bdf8?text=Nova+Ref'],
+        },
+        {
+          id: 'character-drone',
+          project_id: 'demo-reel',
+          name: 'Scout Drone',
+          description: 'Companion drone with adaptive LED faceplate and collapsible wings.',
+          reference_images: ['https://placehold.co/120x160/1e293b/7dd3fc?text=Drone+Ref'],
+        },
+      ],
+      locations: [
+        {
+          id: 'location-rooftop',
+          project_id: 'demo-reel',
+          name: 'Neon Rooftop',
+          description: 'Rain-slick rooftop dotted with antenna arrays and holo-billboards.',
+          type: 'Exterior',
+          reference_images: ['https://placehold.co/160x120/0f172a/38bdf8?text=Rooftop'],
+        },
+        {
+          id: 'location-command',
+          project_id: 'demo-reel',
+          name: 'Command Balcony',
+          description: 'Elevated command balcony overlooking the launch bay.',
+          type: 'Interior',
+          reference_images: ['https://placehold.co/160x120/1e293b/7dd3fc?text=Command'],
+        },
+        {
+          id: 'location-skyway',
+          project_id: 'demo-reel',
+          name: 'Skyway Corridor',
+          description: 'High-speed air lane lined with cargo skiffs and neon signage.',
+          type: 'Exterior',
+          reference_images: ['https://placehold.co/160x120/020617/7dd3fc?text=Skyway'],
+        },
+      ],
+      props: [
+        {
+          id: 'prop-hoverboard',
+          project_id: 'demo-reel',
+          name: 'Mag-Glide Board',
+          description: 'Compact hoverboard with retractable fins and ion thrusters.',
+          category: 'Vehicle',
+          reference_image: 'https://placehold.co/160x120/0f172a/38bdf8?text=Board',
+        },
+        {
+          id: 'prop-console',
+          project_id: 'demo-reel',
+          name: 'Holo Console',
+          description: 'Wearable holographic interface projected from wrist gauntlet.',
+          category: 'Gadget',
+          reference_image: 'https://placehold.co/160x120/1e293b/7dd3fc?text=Console',
+        },
+      ],
+      updated_at: iso('2024-02-12T14:30:00Z'),
+    },
+  ],
+  generations: {
+    'frame-1': [
+      {
+        id: 'gen-color-1',
+        frame_id: 'frame-1',
+        image_url: 'https://placehold.co/1280x720/0ea5e9/020617?text=Color+Keyframe',
+        thumbnail_url: 'https://placehold.co/320x180/0ea5e9/020617?text=Color',
+        type: 'color',
+        prompt:
+          'Hero on rain-soaked rooftop at night, neon reflections, sweeping cinematic lighting, volumetric atmosphere, ultrawide lens.',
+        settings: {
+          mode: 'highFidelity',
+          iterations: 4,
+          style_strength: 80,
+          prompt_weight: 90,
+          aspect_ratio: '16:9',
+          seed: 1042,
+        },
+        is_confirmed: true,
+      },
+      {
+        id: 'gen-bw-1',
+        frame_id: 'frame-1',
+        image_url: 'https://placehold.co/1280x720/1f2937/d1d5db?text=B%26W+Concept',
+        thumbnail_url: 'https://placehold.co/320x180/1f2937/d1d5db?text=B%26W',
+        type: 'blackAndWhite',
+        prompt: 'Noir storyboard sketch of hero overlooking neon city, bold chiaroscuro lighting.',
+        settings: {
+          mode: 'turbo',
+          iterations: 3,
+          style_strength: 65,
+          prompt_weight: 70,
+          aspect_ratio: '16:9',
+          seed: 782,
+        },
+        is_confirmed: false,
+      },
+    ],
+    'frame-2': [
+      {
+        id: 'gen-bw-2',
+        frame_id: 'frame-2',
+        image_url: 'https://placehold.co/1280x720/0b1120/d1d5db?text=Story+Beat',
+        thumbnail_url: 'https://placehold.co/320x180/0b1120/d1d5db?text=Beat',
+        type: 'blackAndWhite',
+        prompt: 'Close-up storyboard sketch, rain droplets refracting holographic light, cinematic focus falloff.',
+        settings: {
+          mode: 'turbo',
+          iterations: 3,
+          style_strength: 68,
+          prompt_weight: 75,
+          aspect_ratio: '16:9',
+          seed: 334,
+        },
+        is_confirmed: true,
+      },
+    ],
+    'frame-3': [
+      {
+        id: 'gen-color-3a',
+        frame_id: 'frame-3',
+        image_url: 'https://placehold.co/1280x720/38bdf8/020617?text=Action+Beat',
+        thumbnail_url: 'https://placehold.co/320x180/38bdf8/020617?text=Action',
+        type: 'color',
+        prompt: 'Hero weaving through neon traffic, motion blur streaks, cinematic camera tilt, vibrant palette.',
+        settings: {
+          mode: 'highFidelity',
+          iterations: 3,
+          style_strength: 82,
+          prompt_weight: 88,
+          aspect_ratio: '16:9',
+          seed: 920,
+        },
+        is_confirmed: false,
+      },
+    ],
+  },
+  videoProviders: [
+    {
+      id: 'flux-motion',
+      name: 'Flux Motion Studio',
+      description: 'Fast previz diffusion tuned for interactive storyboards and animatics.',
+      supported_capabilities: ['Storyboard Import', 'Camera Pathing', 'Text-to-Motion'],
+      max_duration_seconds: 8,
+    },
+    {
+      id: 'aurora-cinematics',
+      name: 'Aurora Cinematics',
+      description: 'High-fidelity motion diffusion for hero shots and marketing beats.',
+      supported_capabilities: ['4K Output', 'Character Consistency', 'Color Script Sync'],
+      max_duration_seconds: 12,
+    },
+  ],
+};
+
+let memoryDatabase: MockDatabase = deepClone(defaultDatabase);
+
+const loadDatabase = (): MockDatabase => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return deepClone(memoryDatabase);
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(memoryDatabase));
+    return deepClone(memoryDatabase);
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as MockDatabase;
+    memoryDatabase = parsed;
+    return deepClone(parsed);
+  } catch (error) {
+    console.warn('Failed to parse storyboard mock database, restoring defaults.', error);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(memoryDatabase));
+    return deepClone(memoryDatabase);
+  }
+};
+
+const saveDatabase = (database: MockDatabase) => {
+  memoryDatabase = deepClone(database);
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(memoryDatabase));
+};
+
+const ensureFrameContext = (database: MockDatabase, frameId: string) => {
+  for (const project of database.projects) {
+    const frame = project.frames.find((item) => item.id === frameId);
+    if (frame) {
+      return { project, frame } as { project: ProjectDetail; frame: Frame };
+    }
+  }
+
+  return null;
+};
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `id-${Math.random().toString(16).slice(2)}`;
+};
+
+const delay = (ms = 180) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const ensureMockData = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  if (!window.localStorage.getItem(STORAGE_KEY)) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(memoryDatabase));
+  }
+};
+
+export const listProjectSummaries = async (): Promise<ProjectSummary[]> => {
+  await delay();
+  const database = loadDatabase();
+
+  return database.projects
+    .slice()
+    .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+    .map((project) => ({
+      id: project.id,
+      name: project.name,
+      description: project.description,
+      frames: project.frames.map((frame) => frame.id),
+      updated_at: project.updated_at,
+    }));
+};
+
+export const getProjectDetail = async (projectId: string): Promise<ProjectDetail> => {
+  await delay();
+  const database = loadDatabase();
+  const project = database.projects.find((item) => item.id === projectId);
+
+  if (!project) {
+    throw new Error('Project not found');
+  }
+
+  return deepClone(project);
+};
+
+export const listGenerations = async (frameId: string): Promise<Generation[]> => {
+  await delay();
+  const database = loadDatabase();
+  const items = database.generations[frameId] ?? [];
+  return deepClone(items);
+};
+
+export const createFrame = async (projectId: string): Promise<Frame> => {
+  await delay();
+  const database = loadDatabase();
+  const project = database.projects.find((item) => item.id === projectId);
+
+  if (!project) {
+    throw new Error('Project not found');
+  }
+
+  const newFrame: Frame = {
+    id: createId(),
+    project_id: projectId,
+    frame_number: project.frames.length + 1,
+    prompt: 'Describe the action in the scene.',
+    sketch: {},
+    metadata: {
+      scene: 'New Story Beat',
+      notes: '',
+    },
+    selected_characters: [],
+    selected_locations: [],
+    selected_props: [],
+    confirmed_image_url: null,
+    confirmed_type: null,
+    confirmed_generation_id: null,
+  };
+
+  project.frames.push(newFrame);
+  database.generations[newFrame.id] = [];
+  project.updated_at = new Date().toISOString();
+
+  saveDatabase(database);
+  return deepClone(newFrame);
+};
+
+export const generateForFrame = async (
+  frameId: string,
+  settings: GenerationSettingsInput,
+): Promise<Generation> => {
+  await delay(320);
+  const database = loadDatabase();
+  const context = ensureFrameContext(database, frameId);
+
+  if (!context) {
+    throw new Error('Frame not found');
+  }
+
+  const { frame, project } = context;
+  const mode = settings.mode;
+  const iterations = settings.iterations ?? (mode === 'turbo' ? 4 : 2);
+  const type = mode === 'highFidelity' ? 'color' : 'blackAndWhite';
+  const seed = Math.floor(Math.random() * 10000);
+  const encodedLabel = encodeURIComponent(`${type === 'color' ? 'Color' : 'B&W'} Draft ${seed}`);
+  const imageUrl =
+    type === 'color'
+      ? `https://placehold.co/1280x720/0ea5e9/020617?text=${encodedLabel}`
+      : `https://placehold.co/1280x720/1f2937/d1d5db?text=${encodedLabel}`;
+
+  const generation: Generation = {
+    id: createId(),
+    frame_id: frameId,
+    image_url: imageUrl,
+    type,
+    prompt:
+      type === 'color'
+        ? `High fidelity color render for frame ${frame.frame_number}, neon accents and cinematic depth.`
+        : `Graphite storyboard pass for frame ${frame.frame_number}, bold contrast and clean silhouettes.`,
+    settings: {
+      mode,
+      iterations,
+      style_strength: mode === 'turbo' ? 65 : 80,
+      prompt_weight: mode === 'turbo' ? 72 : 88,
+      aspect_ratio: '16:9',
+      seed,
+    },
+    is_confirmed: false,
+  };
+
+  if (!database.generations[frameId]) {
+    database.generations[frameId] = [];
+  }
+
+  database.generations[frameId].unshift(generation);
+  project.updated_at = new Date().toISOString();
+
+  saveDatabase(database);
+  return deepClone(generation);
+};
+
+export const confirmGeneration = async (generationId: string): Promise<Generation> => {
+  await delay(220);
+  const database = loadDatabase();
+  let matchedGeneration: Generation | null = null;
+  let matchedFrameId: string | null = null;
+
+  for (const [frameId, items] of Object.entries(database.generations)) {
+    const match = items.find((item) => item.id === generationId);
+    if (match) {
+      matchedGeneration = match;
+      matchedFrameId = frameId;
+      match.is_confirmed = true;
+      break;
+    }
+  }
+
+  if (!matchedGeneration || !matchedFrameId) {
+    throw new Error('Generation not found');
+  }
+
+  const context = ensureFrameContext(database, matchedFrameId);
+  if (context) {
+    context.frame.confirmed_image_url = matchedGeneration.image_url;
+    context.frame.confirmed_type = matchedGeneration.type;
+    context.frame.confirmed_generation_id = matchedGeneration.id;
+    context.project.updated_at = new Date().toISOString();
+  }
+
+  saveDatabase(database);
+  return deepClone(matchedGeneration);
+};
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Failed to read sketch file'));
+    reader.readAsDataURL(file);
+  });
+
+export const uploadSketch = async (projectId: string, frameId: string, file: File): Promise<Frame> => {
+  await delay(260);
+  const database = loadDatabase();
+  const fileData = await readFileAsDataUrl(file);
+  const project = database.projects.find((item) => item.id === projectId);
+
+  if (!project) {
+    throw new Error('Project not found');
+  }
+
+  const frame = project.frames.find((item) => item.id === frameId);
+
+  if (!frame) {
+    throw new Error('Frame not found');
+  }
+
+  frame.sketch = {
+    image_url: fileData,
+    file_name: file.name,
+    uploaded_at: new Date().toISOString(),
+  };
+
+  project.updated_at = new Date().toISOString();
+  saveDatabase(database);
+
+  return deepClone(frame);
+};
+
+export const listVideoProviders = async (): Promise<VideoProvider[]> => {
+  await delay();
+  const database = loadDatabase();
+  return deepClone(database.videoProviders);
+};

--- a/frontend/src/state/types.ts
+++ b/frontend/src/state/types.ts
@@ -1,3 +1,11 @@
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  description?: string;
+  frames?: string[];
+  updated_at: string;
+}
+
 export interface Frame {
   id: string;
   project_id: string;


### PR DESCRIPTION
## Summary
- replace axios-backed API hooks with a browser-friendly mock service so the storyboard UI can run without a server
- seed the mock service with sample projects, frames, and video providers while persisting data to local storage
- remove unused axios/uuid dependencies now that all calls are handled locally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea1b8b9508832a8d78d07d09c53688