### PR TITLE
Add Phone Splat Studio: mobile capture, segmentation and 3D placement prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,3 +467,7 @@ pnpm test
 ## Support
 
 For issues or enhancements, open a ticket or contribute a pull request with clear reproduction steps and tests.
+
+## Phone Splat Studio Prototype
+
+A mobile-first prototype for capturing a person from the camera, isolating them with on-device segmentation, and placing the cutout as a touch-manipulable splat in a 3D scene is available at `mobile-splat/index.html`.

--- a/mobile-splat/app.js
+++ b/mobile-splat/app.js
@@ -1,0 +1,248 @@
+import * as THREE from 'https://unpkg.com/three@0.165.0/build/three.module.js';
+
+const startCameraBtn = document.getElementById('startCameraBtn');
+const captureBtn = document.getElementById('captureBtn');
+const clearSceneBtn = document.getElementById('clearSceneBtn');
+const toggleGridBtn = document.getElementById('toggleGridBtn');
+const softnessSlider = document.getElementById('softnessSlider');
+
+const video = document.getElementById('cameraFeed');
+const overlayCanvas = document.getElementById('overlayCanvas');
+const overlayCtx = overlayCanvas.getContext('2d');
+const sceneContainer = document.getElementById('sceneContainer');
+
+let stream;
+let selfieSegmentation;
+let latestMask = null;
+let latestFrame = null;
+let running = false;
+
+const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+sceneContainer.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x040816);
+const camera = new THREE.PerspectiveCamera(55, 1, 0.1, 100);
+camera.position.set(0, 1.25, 4.2);
+
+const hemi = new THREE.HemisphereLight(0x8cc6ff, 0x141029, 0.9);
+scene.add(hemi);
+
+const ground = new THREE.Mesh(
+  new THREE.PlaneGeometry(20, 20, 30, 30),
+  new THREE.MeshBasicMaterial({ color: 0x071124, wireframe: true, opacity: 0.6, transparent: true })
+);
+ground.rotation.x = -Math.PI / 2;
+scene.add(ground);
+
+const splats = [];
+let activeSplat = null;
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+
+function resizeRenderer() {
+  const { clientWidth, clientHeight } = sceneContainer;
+  renderer.setSize(clientWidth, clientHeight);
+  camera.aspect = clientWidth / clientHeight;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', resizeRenderer);
+resizeRenderer();
+
+function renderScene() {
+  renderer.render(scene, camera);
+  requestAnimationFrame(renderScene);
+}
+renderScene();
+
+async function startCamera() {
+  stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' }, audio: false });
+  video.srcObject = stream;
+  await video.play();
+
+  overlayCanvas.width = video.videoWidth;
+  overlayCanvas.height = video.videoHeight;
+
+  selfieSegmentation = new SelfieSegmentation({
+    locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation/${file}`,
+  });
+
+  selfieSegmentation.setOptions({ modelSelection: 1 });
+  selfieSegmentation.onResults(onSegmentationResults);
+
+  running = true;
+  runSegmentationLoop();
+  captureBtn.disabled = false;
+}
+
+async function runSegmentationLoop() {
+  if (!running || !selfieSegmentation) return;
+
+  await selfieSegmentation.send({ image: video });
+  requestAnimationFrame(runSegmentationLoop);
+}
+
+function onSegmentationResults(results) {
+  if (!results.segmentationMask) {
+    return;
+  }
+
+  const w = overlayCanvas.width;
+  const h = overlayCanvas.height;
+  overlayCtx.clearRect(0, 0, w, h);
+  overlayCtx.drawImage(results.segmentationMask, 0, 0, w, h);
+  overlayCtx.globalCompositeOperation = 'source-in';
+  overlayCtx.drawImage(video, 0, 0, w, h);
+  overlayCtx.globalCompositeOperation = 'source-over';
+
+  latestMask = results.segmentationMask;
+  latestFrame = document.createElement('canvas');
+  latestFrame.width = w;
+  latestFrame.height = h;
+  latestFrame.getContext('2d').drawImage(video, 0, 0, w, h);
+}
+
+function createSplatTexture() {
+  if (!latestMask || !latestFrame) return null;
+
+  const w = latestFrame.width;
+  const h = latestFrame.height;
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+
+  ctx.drawImage(latestMask, 0, 0, w, h);
+  ctx.filter = `blur(${softnessSlider.value}px)`;
+  ctx.globalCompositeOperation = 'source-in';
+  ctx.drawImage(latestFrame, 0, 0, w, h);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.needsUpdate = true;
+  return { tex, ratio: w / h };
+}
+
+function placeSplat(x = 0, z = 0) {
+  const data = createSplatTexture();
+  if (!data) return;
+
+  const material = new THREE.SpriteMaterial({ map: data.tex, transparent: true, depthWrite: false });
+  const sprite = new THREE.Sprite(material);
+  const height = 1.75;
+  sprite.scale.set(height * data.ratio, height, 1);
+  sprite.position.set(x, height / 2, z);
+  scene.add(sprite);
+  splats.push(sprite);
+  activeSplat = sprite;
+}
+
+function toNdc(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+}
+
+function pickSplat(event) {
+  toNdc(event);
+  raycaster.setFromCamera(pointer, camera);
+  const intersections = raycaster.intersectObjects(splats);
+  return intersections[0]?.object ?? null;
+}
+
+function placeOnGround(event) {
+  toNdc(event);
+  raycaster.setFromCamera(pointer, camera);
+  const intersections = raycaster.intersectObject(ground);
+  if (!intersections.length) return;
+  const point = intersections[0].point;
+  placeSplat(point.x, point.z);
+}
+
+let dragPointerId = null;
+let pinchDistance = null;
+let pinchStartScale = null;
+
+renderer.domElement.addEventListener('pointerdown', (event) => {
+  renderer.domElement.setPointerCapture(event.pointerId);
+  const picked = pickSplat(event);
+  if (picked) {
+    activeSplat = picked;
+    dragPointerId = event.pointerId;
+    return;
+  }
+  placeOnGround(event);
+});
+
+renderer.domElement.addEventListener('pointermove', (event) => {
+  if (!activeSplat || dragPointerId !== event.pointerId) return;
+
+  toNdc(event);
+  raycaster.setFromCamera(pointer, camera);
+  const hit = raycaster.intersectObject(ground)[0];
+  if (hit) {
+    activeSplat.position.x = hit.point.x;
+    activeSplat.position.z = hit.point.z;
+  }
+});
+
+renderer.domElement.addEventListener('pointerup', (event) => {
+  if (dragPointerId === event.pointerId) {
+    dragPointerId = null;
+  }
+});
+
+renderer.domElement.addEventListener('touchmove', (event) => {
+  if (!activeSplat) return;
+  if (event.touches.length === 2) {
+    const [a, b] = event.touches;
+    const dist = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+    if (!pinchDistance) {
+      pinchDistance = dist;
+      pinchStartScale = activeSplat.scale.clone();
+      return;
+    }
+
+    const ratio = dist / pinchDistance;
+    activeSplat.scale.copy(pinchStartScale.clone().multiplyScalar(ratio));
+
+    const angle = Math.atan2(b.clientY - a.clientY, b.clientX - a.clientX);
+    activeSplat.material.rotation = angle;
+  }
+}, { passive: true });
+
+renderer.domElement.addEventListener('touchend', () => {
+  pinchDistance = null;
+  pinchStartScale = null;
+});
+
+startCameraBtn.addEventListener('click', async () => {
+  try {
+    startCameraBtn.disabled = true;
+    await startCamera();
+    startCameraBtn.textContent = 'Camera running';
+  } catch (error) {
+    console.error(error);
+    startCameraBtn.disabled = false;
+    alert('Camera permissions are required.');
+  }
+});
+
+captureBtn.addEventListener('click', () => {
+  placeSplat(0, 0);
+});
+
+clearSceneBtn.addEventListener('click', () => {
+  splats.forEach((s) => {
+    scene.remove(s);
+    s.material.map?.dispose();
+    s.material.dispose();
+  });
+  splats.length = 0;
+  activeSplat = null;
+});
+
+toggleGridBtn.addEventListener('click', () => {
+  ground.visible = !ground.visible;
+});

--- a/mobile-splat/index.html
+++ b/mobile-splat/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Phone Splat Studio</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <section class="controls">
+        <h1>Phone Splat Studio</h1>
+        <p>
+          Capture a person, isolate them, then place the result in a 3D scene and pinch to scale.
+        </p>
+
+        <div class="button-row">
+          <button id="startCameraBtn">Start camera</button>
+          <button id="captureBtn" disabled>Capture splat</button>
+        </div>
+
+        <div class="button-row">
+          <button id="toggleGridBtn">Toggle grid</button>
+          <button id="clearSceneBtn">Clear splats</button>
+        </div>
+
+        <label class="slider-field">
+          Splat softness
+          <input id="softnessSlider" type="range" min="0" max="30" value="12" />
+        </label>
+
+        <p class="hint">
+          Tap scene to place. Drag to move selected splat. Pinch to scale. Two-finger rotate to spin.
+        </p>
+      </section>
+
+      <section class="preview-stack">
+        <video id="cameraFeed" playsinline muted></video>
+        <canvas id="overlayCanvas"></canvas>
+      </section>
+
+      <section id="sceneContainer" aria-label="3D placement scene"></section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation/selfie_segmentation.js"></script>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/mobile-splat/styles.css
+++ b/mobile-splat/styles.css
@@ -1,0 +1,88 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: #070b15;
+  color: #e2f0ff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100svh;
+  background: radial-gradient(circle at top, #131d35 0, #070b15 60%);
+}
+
+.app-shell {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-rows: auto auto minmax(280px, 1fr);
+  padding: 0.9rem;
+}
+
+.controls {
+  padding: 0.8rem;
+  border: 1px solid #2a3d60;
+  border-radius: 14px;
+  background: rgba(8, 15, 28, 0.9);
+}
+
+h1 { margin: 0; font-size: 1.2rem; }
+p { margin: 0.45rem 0; }
+
+.button-row {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(130deg, #3d78ff, #7f4bff);
+  color: white;
+  padding: 0.6rem 0.95rem;
+  font-weight: 600;
+}
+
+button:disabled {
+  opacity: 0.45;
+}
+
+.slider-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.preview-stack {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #2a3d60;
+}
+
+video,
+#overlayCanvas {
+  width: 100%;
+  display: block;
+}
+
+#overlayCanvas {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+#sceneContainer {
+  border-radius: 12px;
+  overflow: hidden;
+  min-height: 300px;
+  border: 1px solid #2a3d60;
+  background: #03060e;
+}
+
+.hint {
+  color: #8cb4ff;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
### Motivation
- Provide a mobile-first prototype that lets a phone user capture a person, isolate the subject on-device, and place the cutout into a simple 3D scene for quick composition and touch-based editing.
- Enable an interactive workflow (tap-to-place, drag, pinch-to-scale, two-finger rotate) that can be tested in a mobile browser without server-side processing.

### Description
- Added a new standalone prototype under `mobile-splat/` with three files: `index.html`, `styles.css`, and `app.js`, and a README pointer to the entry page.
- Implemented live person isolation using MediaPipe `SelfieSegmentation` to produce a mask which is combined with the camera frame on a canvas and blurred according to the `Splat softness` slider.
- Created a Three.js placement scene where the masked capture is converted to a `CanvasTexture` and shown as a sprite; splats can be placed on a ground plane and manipulated via pointer and touch handlers (drag, pinch scale, two-finger rotate, clear, toggle grid).
- UI includes camera start, capture, grid toggle, clear scene, and softness controls, and the prototype is client-side so it runs directly from `mobile-splat/index.html` in a browser with camera permissions.

### Testing
- Ran `node --check mobile-splat/app.js` which completed successfully.
- Attempted `node --check mobile-splat/index.html` which fails because Node’s syntax checker does not accept HTML files (expected limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb28e6286c832a8030a1ae06a47283)